### PR TITLE
Raise exception on missing augeasproviders_core

### DIFF
--- a/lib/puppet/provider/apache_directive/augeas.rb
+++ b/lib/puppet/provider/apache_directive/augeas.rb
@@ -1,13 +1,15 @@
+# coding: utf-8
 # Manages an Apache directive
 #
 # Copyright (c) 2013 Raphaël Pinson
 # Licensed under the Apache License, Version 2.0
 
+raise("Missing augeasproviders_core dependency") if Puppet::Type.type(:augeasprovider).nil?
 Puppet::Type.type(:apache_directive).provide(:augeas, :parent => Puppet::Type.type(:augeasprovider).provider(:default)) do
   desc 'Use the Augeas API to update a directive in Apache'
 
   lens { 'Httpd.lns' }
-  
+
   default_file do
     case Facter.value(:osfamily)
     when 'RedHat'

--- a/lib/puppet/provider/apache_setenv/augeas.rb
+++ b/lib/puppet/provider/apache_setenv/augeas.rb
@@ -3,6 +3,7 @@
 # Copyright (c) 2013 Endre Karlson
 # Licensed under the Apache License, Version 2.0
 
+raise("Missing augeasproviders_core dependency") if Puppet::Type.type(:augeasprovider).nil?
 Puppet::Type.type(:apache_setenv).provide(:augeas, :parent => Puppet::Type.type(:augeasprovider).provider(:default)) do
   desc "Use Augeas API to update SetEnv in Apache"
 


### PR DESCRIPTION
People who manage their code with r10k have to resolve dependencies by
hand (or using a generator), as such we now helpfully raise an exception
when miaugeasproviders_core is missing.