### PR TITLE
Support Puppet 5

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ spec/fixtures/manifests
 spec/fixtures/modules
 yardoc/
 .yardoc/
+Gemfile.lock
 
 ## Ruby
 .rvmrc*

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,66 +1,31 @@
 language: ruby
+dist: precise
 sudo: required
 rvm:
-  - 1.8.7
-  - 1.9.3
-  - 2.0.0
+  - 2.1.9
+  # Ruby with Puppet 5
+  - 2.4.0
 notifications:
   email:
    - raphael.pinson@camptocamp.com
 env:
 # base env
-  # Most tests with oldest supported ruby-augeas
-  - PUPPET=3.0.0 RUBY_AUGEAS=0.3.0 AUGEAS=1.1.0
-  - PUPPET=3.2.0 RUBY_AUGEAS=0.3.0 AUGEAS=1.1.0
-  - PUPPET=3.4 RUBY_AUGEAS=0.3.0 AUGEAS=1.1.0
-  # Test the latest ruby-augeas (~>)
-  - PUPPET=3.2.0 RUBY_AUGEAS=0.5
-    # Use this build to publish on the forge
-  - PUPPET=3.4 RUBY_AUGEAS=0.5 FORGE_PUBLISH=true
-  # Test other versions of Augeas
-  - PUPPET=3.4 RUBY_AUGEAS=0.3.0 AUGEAS=0.10.0
-  - PUPPET=3.4 RUBY_AUGEAS=0.3.0 AUGEAS=1.0.0
-  - PUPPET=3.4 RUBY_AUGEAS=0.3.0 AUGEAS=1.1.0
-  - PUPPET=2.7.0 RUBY_AUGEAS=0.3.0 AUGEAS=1.2.0
-  - PUPPET=3.4 RUBY_AUGEAS=0.3.0 AUGEAS=1.2.0
-  # Issue #83: test old Augeas with new lenses
-  - PUPPET=3.4 RUBY_AUGEAS=0.3.0 AUGEAS=1.0.0 LENSES=HEAD
-  - PUPPET=3.4 RUBY_AUGEAS=0.3.0 AUGEAS=1.1.0 LENSES=HEAD
-  - PUPPET=3.4 RUBY_AUGEAS=0.5 AUGEAS=1.0.0 LENSES=HEAD
-  - PUPPET=3.4 RUBY_AUGEAS=0.5 AUGEAS=1.1.0 LENSES=HEAD
-  # Test latest Puppet version
+  # Test Puppet 4
   - PUPPET=4.0 RUBY_AUGEAS=0.5
-
+  # Test Oldest Puppet, Inc. supported Puppet
+  - PUPPET=4.7.1 RUBY_AUGEAS=0.5 FORGE_PUBLISH=true
+  # Test latest Puppet version
+  - PUPPET=5.0 RUBY_AUGEAS=0.5
 
 matrix:
   fast_finish: true
+  allow_failures:
+    - env: PUPPET=5.0 RUBY_AUGEAS=0.5
   exclude:
 # base exclude
-    # No support for Ruby 2.0 before Puppet 3.2.0 and ruby-augeas 0.5
-    - rvm: 2.0.0
-      env: PUPPET=3.0.0 RUBY_AUGEAS=0.3.0
-    - rvm: 2.0.0
-      env: PUPPET=3.2.0 RUBY_AUGEAS=0.3.0
-    - rvm: 2.0.0
-      env: PUPPET=3.4 RUBY_AUGEAS=0.3.0
-    - rvm: 2.0.0
-      env: PUPPET=3.4 RUBY_AUGEAS=0.3.0 AUGEAS=0.10.0
-    - rvm: 2.0.0
-      env: PUPPET=3.4 RUBY_AUGEAS=0.3.0 AUGEAS=1.0.0
-    - rvm: 2.0.0
-      env: PUPPET=3.4 RUBY_AUGEAS=0.3.0 AUGEAS=1.1.0
-    - rvm: 2.0.0
-      env: PUPPET=3.0.0 RUBY_AUGEAS=0.3.0 AUGEAS=1.1.0
-    - rvm: 2.0.0
-      env: PUPPET=3.4 RUBY_AUGEAS=0.3.0 AUGEAS=1.2.0
-    - rvm: 2.0.0
-      env: PUPPET=3.4 RUBY_AUGEAS=0.3.0 AUGEAS=1.0.0 LENSES=HEAD
-    - rvm: 2.0.0
-      env: PUPPET=3.4 RUBY_AUGEAS=0.3.0 AUGEAS=1.1.0 LENSES=HEAD
-    # No support for Ruby 1.8 in Puppet 4
-    - rvm: 1.8.7
-      env: PUPPET=4.0 RUBY_AUGEAS=0.5
-
+    # No support for Ruby 2.1.9 in Puppet 5
+    - rvm: 2.1.9
+      env: PUPPET=5.0 RUBY_AUGEAS=0.5
 
 install:
   - "travis_retry ./.travis.sh"
@@ -78,5 +43,5 @@ deploy:
     # all_branches is required to use tags
     all_branches: true
     # Only publish if our main Ruby target builds
-    rvm: 1.9.3
+    rvm: 2.1.9
     condition: "$FORGE_PUBLISH = true"

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,10 +19,8 @@ env:
 
 matrix:
   fast_finish: true
-  allow_failures:
-    - env: PUPPET=5.0 RUBY_AUGEAS=0.5
   exclude:
-# base exclude
+    # base exclude
     # No support for Ruby 2.1.9 in Puppet 5
     - rvm: 2.1.9
       env: PUPPET=5.0 RUBY_AUGEAS=0.5

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2.0.2
+
+- Upped supported Puppet versions to include Puppet 5
+
 ## 2.0.1
 
 - Fix metadata.json

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "herculesteam-augeasproviders_apache",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "author": "Dominic Cleal, Raphael Pinson",
   "summary": "Augeas-based apache types and providers for Puppet",
   "license": "Apache-2.0",
@@ -48,7 +48,7 @@
   "requirements": [
     {
       "name": "puppet",
-      "version_requirement": ">= 2.7.0 < 5.0.0"
+      "version_requirement": ">= 2.7.0 < 6.0.0"
     }
   ]
 }

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -34,7 +34,7 @@ Puppet[:modulepath] = File.join(dir, 'fixtures', 'modules')
 # ticket https://tickets.puppetlabs.com/browse/MODULES-823
 #
 ver = Gem::Version.new(Puppet.version.split('-').first)
-if Gem::Requirement.new("~> 2.7.20") =~ ver || Gem::Requirement.new("~> 3.0.0") =~ ver || Gem::Requirement.new("~> 3.5") =~ ver || Gem::Requirement.new("~> 4.0") =~ ver
+if Gem::Requirement.new("~> 2.7.20") =~ ver || Gem::Requirement.new("~> 3.0.0") =~ ver || Gem::Requirement.new("~> 3.5") =~ ver || Gem::Requirement.new("~> 4.0") =~ ver || Gem::Requirement.new("~> 5.0") =~ ver
   puts "augeasproviders: setting Puppet[:libdir] to work around broken type autoloading"
   # libdir is only a single dir, so it can only workaround loading of one external module
   Puppet[:libdir] = "#{Puppet[:modulepath]}/augeasproviders_core/lib"


### PR DESCRIPTION
- Upped supported Puppet versions to include Puppet 5
- Bumped version to 2.0.2